### PR TITLE
Chore: Adding a vanilla CI pipeline

### DIFF
--- a/.github/workflows/ci-application.yml
+++ b/.github/workflows/ci-application.yml
@@ -25,10 +25,6 @@ jobs:
           dotnet-version: |
             8.0.x
 
-      - name: Install DotNet Tools and Run Husky
-        run: |
-          dotnet tool restore
-
       - name: Restore Dependencies
         run: dotnet restore ${{ inputs.project-path }}
 

--- a/.github/workflows/ci-application.yml
+++ b/.github/workflows/ci-application.yml
@@ -1,0 +1,36 @@
+﻿name: CI Application
+
+on:
+  workflow_call:
+    inputs:
+      project-path:
+        type: string
+        required: true
+        description: Path to the csproj file
+        
+permissions: 
+    contents: read
+
+jobs:
+  ci_validations:
+    name: Restore, Build, and Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+
+      - name: Install DotNet Tools and Run Husky
+        run: |
+          dotnet tool restore
+
+      - name: Restore Dependencies
+        run: dotnet restore ${{ inputs.project-path }}
+
+      - name: Build Project
+        run: dotnet build --configuration Release --no-restore ${{ inputs.project-path }}

--- a/.github/workflows/cicd-funky-apim.yml
+++ b/.github/workflows/cicd-funky-apim.yml
@@ -1,0 +1,19 @@
+﻿name: cicd_funky_apim
+concurrency: cicd_funky_apim
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request: 
+    branches:
+      - main
+
+
+jobs:
+  ci:
+    name: CI
+    uses: ./.github/workflows/ci-application.yml
+    with:
+      project-path: src/FunkyOrders/FunkyOrders.csproj


### PR DESCRIPTION
# Changes

✅ Adding a vanilla CI pipeline which checkout code, restore and build the project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Introduced new GitHub Actions workflows for continuous integration and deployment.
  - Added a reusable workflow to validate and build .NET projects.
  - Set up automated CI/CD for the FunkyOrders project with concurrency control to prevent overlapping runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->